### PR TITLE
Patch #4 and #15: frontrunning via `_transfer_in()`

### DIFF
--- a/Forc.toml
+++ b/Forc.toml
@@ -1,18 +1,18 @@
 [workspace]
 members = [
-    # "contracts/fungible",
-    # "contracts/pricefeed",
-    # "contracts/core/vault-pricefeed",
+    "contracts/fungible",
+    "contracts/pricefeed",
+    "contracts/core/vault-pricefeed",
 
-    # "contracts/core/vault-storage",
-    # "contracts/core/vault-utils",
+    "contracts/core/vault-storage",
+    "contracts/core/vault-utils",
     "contracts/core/vault",
 
-    # "contracts/assets/yield-tracker",
-    # "contracts/assets/yield-asset",
-    # "contracts/assets/rusd",
-    # "contracts/assets/time-distributor",
-    # "contracts/assets/rlp",
+    "contracts/assets/yield-tracker",
+    "contracts/assets/yield-asset",
+    "contracts/assets/rusd",
+    "contracts/assets/time-distributor",
+    "contracts/assets/rlp",
 
-    # "contracts/utils",
+    "contracts/utils",
 ]

--- a/Forc.toml
+++ b/Forc.toml
@@ -1,17 +1,17 @@
 [workspace]
 members = [
-    "contracts/fungible",
-    "contracts/core/vault-pricefeed",
+    # "contracts/fungible",
+    # "contracts/core/vault-pricefeed",
 
-    "contracts/core/vault-storage",
-    "contracts/core/vault-utils",
+    # "contracts/core/vault-storage",
+    # "contracts/core/vault-utils",
     "contracts/core/vault",
 
-    "contracts/assets/yield-tracker",
-    "contracts/assets/yield-asset",
-    "contracts/assets/rusd",
-    "contracts/assets/time-distributor",
-    "contracts/assets/rlp",
+    # "contracts/assets/yield-tracker",
+    # "contracts/assets/yield-asset",
+    # "contracts/assets/rusd",
+    # "contracts/assets/time-distributor",
+    # "contracts/assets/rlp",
 
-    "contracts/utils",
+    # "contracts/utils",
 ]

--- a/Forc.toml
+++ b/Forc.toml
@@ -1,17 +1,18 @@
 [workspace]
 members = [
-    # "contracts/fungible",
-    # "contracts/core/vault-pricefeed",
+    "contracts/fungible",
+    "contracts/pricefeed",
+    "contracts/core/vault-pricefeed",
 
-    # "contracts/core/vault-storage",
-    # "contracts/core/vault-utils",
+    "contracts/core/vault-storage",
+    "contracts/core/vault-utils",
     "contracts/core/vault",
 
-    # "contracts/assets/yield-tracker",
-    # "contracts/assets/yield-asset",
-    # "contracts/assets/rusd",
-    # "contracts/assets/time-distributor",
-    # "contracts/assets/rlp",
+    "contracts/assets/yield-tracker",
+    "contracts/assets/yield-asset",
+    "contracts/assets/rusd",
+    "contracts/assets/time-distributor",
+    "contracts/assets/rlp",
 
-    # "contracts/utils",
+    "contracts/utils",
 ]

--- a/Forc.toml
+++ b/Forc.toml
@@ -1,18 +1,18 @@
 [workspace]
 members = [
-    "contracts/fungible",
-    "contracts/pricefeed",
-    "contracts/core/vault-pricefeed",
+    # "contracts/fungible",
+    # "contracts/pricefeed",
+    # "contracts/core/vault-pricefeed",
 
-    "contracts/core/vault-storage",
-    "contracts/core/vault-utils",
+    # "contracts/core/vault-storage",
+    # "contracts/core/vault-utils",
     "contracts/core/vault",
 
-    "contracts/assets/yield-tracker",
-    "contracts/assets/yield-asset",
-    "contracts/assets/rusd",
-    "contracts/assets/time-distributor",
-    "contracts/assets/rlp",
+    # "contracts/assets/yield-tracker",
+    # "contracts/assets/yield-asset",
+    # "contracts/assets/rusd",
+    # "contracts/assets/time-distributor",
+    # "contracts/assets/rlp",
 
-    "contracts/utils",
+    # "contracts/utils",
 ]

--- a/contracts/assets/rusd/src/main.sw
+++ b/contracts/assets/rusd/src/main.sw
@@ -353,10 +353,10 @@ fn _burn(
 
     _update_rewards(account);
 
-    let account_balance = storage.balances.get(account).try_read().unwrap_or(0);
-    require(account_balance >= amount, Error::YieldAssetBurnAmountExceedsBalance);
+    // let account_balance = storage.balances.get(account).try_read().unwrap_or(0);
+    // require(account_balance >= amount, Error::YieldAssetBurnAmountExceedsBalance);
 
-    storage.balances.get(account).write(account_balance - amount);
+    // storage.balances.get(account).write(account_balance - amount);
     storage.total_supply.write(storage.total_supply.read() - amount);
 
     if storage.non_staking_accounts.get(account).try_read().unwrap_or(false) {

--- a/contracts/core/interfaces/src/vault.sw
+++ b/contracts/core/interfaces/src/vault.sw
@@ -35,9 +35,9 @@ abi Vault {
     #[storage(read)]
     fn get_gov() -> Account;
 
-    fn get_vault_storage() -> ContractId;
+    // fn get_vault_storage() -> ContractId;
 
-    fn get_vault_utils() -> ContractId;
+    // fn get_vault_utils() -> ContractId;
 
     /*
           ____  ____        _     _ _      

--- a/contracts/core/interfaces/src/vault.sw
+++ b/contracts/core/interfaces/src/vault.sw
@@ -49,8 +49,10 @@ abi Vault {
     #[payable]
     fn direct_pool_deposit(asset: AssetId);
 
+    #[payable]
     fn buy_rusd(asset: AssetId, receiver: Account) -> u256;
 
+    #[payable]
     fn sell_rusd(asset: AssetId, receiver: Account) -> u256;
 
     #[payable]

--- a/contracts/core/interfaces/src/vault_storage.sw
+++ b/contracts/core/interfaces/src/vault_storage.sw
@@ -241,9 +241,6 @@ abi VaultStorage {
       /_/_/    |_|    \__,_|_.__/|_|_|\___|
     */
     #[storage(write)]
-    fn write_asset_balance(asset: AssetId, bal: u64);
-
-    #[storage(write)]
     fn write_last_funding_time(asset: AssetId, last_funding_time: u64);
 
     #[storage(write)]

--- a/contracts/core/vault-storage/src/main.sw
+++ b/contracts/core/vault-storage/src/main.sw
@@ -99,8 +99,6 @@ storage {
     // allows setting a max amount of RUSD debt for an asset
     max_rusd_amounts: StorageMap<AssetId, u256> = StorageMap::<AssetId, u256> {},
 
-    // used only to determine _transfer_in values
-    asset_balances: StorageMap<AssetId, u64> = StorageMap::<AssetId, u64> {},
     // allows specification of an amount to exclude from swaps
     // can be used to ensure a certain amount of liquidity is available for leverage positions
     buffer_amounts: StorageMap<AssetId, u256> = StorageMap::<AssetId, u256> {},
@@ -537,7 +535,9 @@ impl VaultStorage for Contract {
 
     #[storage(read)]
     fn get_asset_balance(asset: AssetId) -> u64 {
-        storage.asset_balances.get(asset).try_read().unwrap_or(0)
+        // this is not used at all. Removing this breaks compiler inlining however, so this 
+        // remains until a more stable compiler is available
+        0
     }
 
     #[storage(read)]
@@ -580,14 +580,6 @@ impl VaultStorage for Contract {
     #[storage(write)]
     fn set_router(router: Account, is_active: bool) {
         storage.approved_routers.get(get_sender()).insert(router, is_active);
-    }
-
-    #[storage(write)]
-    fn write_asset_balance(asset: AssetId, balance: u64) {
-        _only_write_authorized();
-
-        storage.asset_balances.insert(asset, balance);
-        log(WriteAssetBalance { asset, balance });
     }
 
     #[storage(write)]

--- a/contracts/core/vault-utils/src/main.sw
+++ b/contracts/core/vault-utils/src/main.sw
@@ -55,7 +55,7 @@ storage {
     rusd_amounts: StorageMap<AssetId, u256> = StorageMap::<AssetId, u256> {},
 
     // tracks the number of received tokens that can be used for leverage
-    // tracked separately from asset_balances to exclude funds that are deposited 
+    // tracked separately to exclude funds that are deposited 
     // as margin collateral
     pool_amounts: StorageMap<AssetId, u256> = StorageMap::<AssetId, u256> {},
     // tracks the amount of USD that is "guaranteed" by opened leverage positions

--- a/contracts/core/vault/src/errors.sw
+++ b/contracts/core/vault/src/errors.sw
@@ -10,9 +10,10 @@ pub enum Error {
     VaultReceiverCannotBeZero: (),
 
     VaultAssetNotWhitelisted: (),
-    VaultInvalidAssetAmount: (),
     VaultInvalidRusdAmount: (),
     VaultInvalidRedemptionAmount: (),
+
+    VaultInvalidAssetForwarded: (),
     VaultZeroAmountOfAssetForwarded: (),
 
     VaultInvalidAmountOut: (),
@@ -38,11 +39,11 @@ pub enum Error {
     VaultInvalidPosition: (),
     VaultInvalidPositionSize: (),
 
+    VaultCollateralAssetNotWhitelisted: (),
+
     VaultLongCollateralIndexAssetsMismatch: (),
-    VaultLongCollateralAssetNotWhitelisted: (),
     VaultLongCollateralAssetMustNotBeStableAsset: (),
 
-    VaultShortCollateralAssetNotWhitelisted: (),
     VaultShortCollateralAssetMustBeStableAsset: (),
     VaultShortIndexAssetMustNotBeStableAsset: (),
     VaultShortIndexAssetNotShortable: (),

--- a/contracts/core/vault/src/errors.sw
+++ b/contracts/core/vault/src/errors.sw
@@ -10,11 +10,11 @@ pub enum Error {
     VaultReceiverCannotBeZero: (),
 
     VaultAssetNotWhitelisted: (),
+    VaultInvalidAssetAmount: (),
     VaultInvalidRusdAmount: (),
     VaultInvalidRedemptionAmount: (),
 
     VaultInvalidAssetForwarded: (),
-    VaultZeroAmountOfAssetForwarded: (),
 
     VaultInvalidAmountOut: (),
 

--- a/contracts/core/vault/src/internals.sw
+++ b/contracts/core/vault/src/internals.sw
@@ -2,6 +2,7 @@
 library;
 
 use std::{
+    call_frames::msg_asset_id,
     context::*,
     primitive_conversions::{
         u8::*,
@@ -66,17 +67,20 @@ pub fn _validate_assets(
 ) {
     let vault_storage = abi(VaultStorage, vault_storage_.into());
 
+    require(
+        vault_storage.is_asset_whitelisted(collateral_asset),
+        Error::VaultCollateralAssetNotWhitelisted
+    );
+
+    let collateral_is_stable = vault_storage.is_stable_asset(collateral_asset);
+
     if is_long {
         require(
             collateral_asset == index_asset,
             Error::VaultLongCollateralIndexAssetsMismatch
         );
         require(
-            vault_storage.is_asset_whitelisted(collateral_asset),
-            Error::VaultLongCollateralAssetNotWhitelisted
-        );
-        require(
-            !vault_storage.is_stable_asset(collateral_asset),
+            !collateral_is_stable,
             Error::VaultLongCollateralAssetMustNotBeStableAsset
         );
 
@@ -84,11 +88,7 @@ pub fn _validate_assets(
     }
 
     require(
-        vault_storage.is_asset_whitelisted(collateral_asset),
-        Error::VaultShortCollateralAssetNotWhitelisted
-    );
-    require(
-        vault_storage.is_stable_asset(collateral_asset),
+        collateral_is_stable,
         Error::VaultShortCollateralAssetMustBeStableAsset
     );
     require(

--- a/contracts/core/vault/src/internals.sw
+++ b/contracts/core/vault/src/internals.sw
@@ -129,35 +129,31 @@ pub fn _validate_buffer_amount(
     }
 }
 
-pub fn _transfer_in(asset_id: AssetId, vault_storage_: ContractId) -> u64 {
-    let vault_storage = abi(VaultStorage, vault_storage_.into());
-    
-    let prev_balance = vault_storage.get_asset_balance(asset_id);
-    let next_balance = balance_of(ContractId::this(), asset_id);
-    vault_storage.write_asset_balance(asset_id, next_balance);
-
+pub fn _transfer_in(asset_id: AssetId) -> u64 {
     require(
-        next_balance >= prev_balance,
-        Error::VaultZeroAmountOfAssetForwarded
+        msg_asset_id() == asset_id,
+        Error::VaultInvalidAssetForwarded
     );
 
-    next_balance - prev_balance
+    let amount = msg_amount();
+    require(
+        amount > 0,
+        Error::VaultZeroAmountOfAssetForwarded
+    );
+    
+    amount
 }
 
 pub fn _transfer_out(
     asset_id: AssetId, 
     amount: u64, 
-    receiver: Account,
-    vault_storage_: ContractId
+    receiver: Account
 ) {
-    let vault_storage = abi(VaultStorage, vault_storage_.into());
-
     transfer_assets(
         asset_id,
         receiver,
         amount
     );
-    vault_storage.write_asset_balance(asset_id, balance_of(ContractId::this(), asset_id));
 }
 
 // for longs:  next_average_price = (next_price * next_size) / (next_size + delta)

--- a/contracts/core/vault/src/internals.sw
+++ b/contracts/core/vault/src/internals.sw
@@ -134,11 +134,6 @@ pub fn _transfer_in(asset_id: AssetId) -> u64 {
         msg_asset_id() == asset_id,
         Error::VaultInvalidAssetForwarded
     );
-
-    require(
-        msg_amount() > 0,
-        Error::VaultZeroAmountOfAssetForwarded
-    );
     
     msg_amount()
 }

--- a/contracts/core/vault/src/internals.sw
+++ b/contracts/core/vault/src/internals.sw
@@ -130,10 +130,12 @@ pub fn _validate_buffer_amount(
 }
 
 pub fn _transfer_in(asset_id: AssetId) -> u64 {
-    require(
-        msg_asset_id() == asset_id,
-        Error::VaultInvalidAssetForwarded
-    );
+    if msg_amount() > 0 {
+        require(
+            msg_asset_id() == asset_id,
+            Error::VaultInvalidAssetForwarded
+        );
+    }
     
     msg_amount()
 }

--- a/contracts/core/vault/src/internals.sw
+++ b/contracts/core/vault/src/internals.sw
@@ -135,13 +135,12 @@ pub fn _transfer_in(asset_id: AssetId) -> u64 {
         Error::VaultInvalidAssetForwarded
     );
 
-    let amount = msg_amount();
     require(
-        amount > 0,
+        msg_amount() > 0,
         Error::VaultZeroAmountOfAssetForwarded
     );
     
-    amount
+    msg_amount()
 }
 
 pub fn _transfer_out(

--- a/contracts/core/vault/src/main.sw
+++ b/contracts/core/vault/src/main.sw
@@ -119,6 +119,7 @@ impl Vault for Contract {
         );
     }
 
+    #[payable]
     fn buy_rusd(asset: AssetId, receiver: Account) -> u256 {
         _buy_rusd(
             asset,
@@ -128,6 +129,7 @@ impl Vault for Contract {
         )
     }
 
+    #[payable]
     fn sell_rusd(asset: AssetId, receiver: Account) -> u256 {
         _sell_rusd(
             asset,

--- a/contracts/core/vault/src/main.sw
+++ b/contracts/core/vault/src/main.sw
@@ -95,13 +95,13 @@ impl Vault for Contract {
         storage.gov.read()
     }
 
-    fn get_vault_storage() -> ContractId {
-        VAULT_STORAGE
-    }
+    // fn get_vault_storage() -> ContractId {
+    //     VAULT_STORAGE
+    // }
 
-    fn get_vault_utils() -> ContractId {
-        VAULT_UTILS
-    }
+    // fn get_vault_utils() -> ContractId {
+    //     VAULT_UTILS
+    // }
 
     /*
           ____  ____        _     _ _      

--- a/contracts/core/vault/src/utils.sw
+++ b/contracts/core/vault/src/utils.sw
@@ -104,7 +104,7 @@ pub fn _increase_position(
         vault_utils_
     );
 
-    let collateral_delta = _transfer_in(collateral_asset, vault_storage_).as_u256();
+    let collateral_delta = _transfer_in(collateral_asset).as_u256();
     let collateral_delta_usd = vault_utils.asset_to_usd_min(collateral_asset, collateral_delta);
 
     position.collateral = position.collateral + collateral_delta_usd;
@@ -367,8 +367,7 @@ pub fn _decrease_position(
         _transfer_out(
             collateral_asset, 
             u64::try_from(amount_out_after_fees).unwrap(), 
-            receiver,
-            vault_storage_
+            receiver
         );
         
         vault_storage.write_position(position_key, position);
@@ -615,8 +614,7 @@ pub fn _liquidate_position(
         collateral_asset, 
         // @TODO: potential revert here
         u64::try_from(vault_utils.usd_to_asset_min(collateral_asset, liquidation_fee_usd)).unwrap(),
-        fee_receiver,
-        vault_storage_
+        fee_receiver
     );
 }
 
@@ -648,7 +646,7 @@ pub fn _swap(
     vault_utils.update_cumulative_funding_rate(asset_in, asset_in);
     vault_utils.update_cumulative_funding_rate(asset_out, asset_out);
 
-    let amount_in = _transfer_in(asset_in, vault_storage_).as_u256();
+    let amount_in = _transfer_in(asset_in).as_u256();
 
     let price_in = vault_utils.get_min_price(asset_in);
     let price_out = vault_utils.get_max_price(asset_out);
@@ -685,7 +683,7 @@ pub fn _swap(
 
     _validate_buffer_amount(asset_out, vault_storage_, vault_utils_);
 
-    _transfer_out(asset_out, amount_out_after_fees, receiver, vault_storage_);
+    _transfer_out(asset_out, amount_out_after_fees, receiver);
 
     log(Swap {
         account: receiver,
@@ -721,7 +719,7 @@ pub fn _sell_rusd(
 
     let rusd = vault_storage.get_rusd();
 
-    let rusd_amount = _transfer_in(rusd, vault_storage_).as_u256();
+    let rusd_amount = _transfer_in(rusd).as_u256();
 
     vault_utils.update_cumulative_funding_rate(asset, asset);
 
@@ -748,13 +746,8 @@ pub fn _sell_rusd(
         _amount
     );
 
-    // the _transferIn call increased the value of tokenBalances[rusd]
-    // usually decreases in token balances are synced by calling _transferOut
-    // however, for UDFG, the assets are burnt, so _updateTokenBalance should
-    // be manually called to record the decrease in assets
     // update asset balance
     let next_balance = balance_of(ContractId::this(), asset);
-    vault_storage.write_asset_balance(asset, next_balance);
 
     // _get_sell_rusd_fee_basis_points
     let fee_basis_points = vault_utils.get_fee_basis_points(
@@ -774,7 +767,7 @@ pub fn _sell_rusd(
     );
     require(amount_out > 0, Error::VaultInvalidAmountOut);
 
-    _transfer_out(asset, amount_out, receiver, vault_storage_);
+    _transfer_out(asset, amount_out, receiver);
 
     log(SellRUSD {
         account: receiver,
@@ -806,7 +799,7 @@ pub fn _buy_rusd(
         Error::VaultAssetNotWhitelisted
     );
 
-    let asset_amount = _transfer_in(asset, vault_storage_);
+    let asset_amount = _transfer_in(asset);
 
     vault_utils.update_cumulative_funding_rate(asset, asset);
 
@@ -879,7 +872,7 @@ pub fn _direct_pool_deposit(
         Error::VaultAssetNotWhitelisted
     );
 
-    let amount = _transfer_in(asset, vault_storage_).as_u256();
+    let amount = _transfer_in(asset).as_u256();
 
     vault_utils.increase_pool_amount(asset, amount);
 
@@ -906,8 +899,7 @@ pub fn _withdraw_fees(
     _transfer_out(
         asset,
         u64::try_from(amount).unwrap(),
-        receiver,
-        vault_storage_
+        receiver
     );
 
     log(WithdrawFees {

--- a/contracts/core/vault/src/utils.sw
+++ b/contracts/core/vault/src/utils.sw
@@ -647,6 +647,7 @@ pub fn _swap(
     vault_utils.update_cumulative_funding_rate(asset_out, asset_out);
 
     let amount_in = _transfer_in(asset_in).as_u256();
+    require(amount_in > 0, Error::VaultInvalidAmountIn);
 
     let price_in = vault_utils.get_min_price(asset_in);
     let price_out = vault_utils.get_max_price(asset_out);
@@ -720,6 +721,7 @@ pub fn _sell_rusd(
     let rusd = vault_storage.get_rusd();
 
     let rusd_amount = _transfer_in(rusd).as_u256();
+    require(rusd_amount > 0, Error::VaultInvalidRusdAmount);
 
     vault_utils.update_cumulative_funding_rate(asset, asset);
 
@@ -747,7 +749,7 @@ pub fn _sell_rusd(
     );
 
     // update asset balance
-    let next_balance = balance_of(ContractId::this(), asset);
+    let _next_balance = balance_of(ContractId::this(), asset);
 
     let fee_basis_points = vault_utils.get_fee_basis_points(
         asset,
@@ -799,6 +801,7 @@ pub fn _buy_rusd(
     );
 
     let asset_amount = _transfer_in(asset);
+    require(asset_amount > 0, Error::VaultInvalidAssetAmount);
 
     vault_utils.update_cumulative_funding_rate(asset, asset);
 
@@ -871,6 +874,7 @@ pub fn _direct_pool_deposit(
     );
 
     let amount = _transfer_in(asset).as_u256();
+    require(amount > 0, Error::VaultInvalidAssetAmount);
 
     vault_utils.increase_pool_amount(asset, amount);
 

--- a/contracts/core/vault/src/utils.sw
+++ b/contracts/core/vault/src/utils.sw
@@ -649,7 +649,6 @@ pub fn _swap(
     vault_utils.update_cumulative_funding_rate(asset_out, asset_out);
 
     let amount_in = _transfer_in(asset_in, vault_storage_).as_u256();
-    require(amount_in > 0, Error::VaultInvalidAmountIn);
 
     let price_in = vault_utils.get_min_price(asset_in);
     let price_out = vault_utils.get_max_price(asset_out);
@@ -723,7 +722,6 @@ pub fn _sell_rusd(
     let rusd = vault_storage.get_rusd();
 
     let rusd_amount = _transfer_in(rusd, vault_storage_).as_u256();
-    require(rusd_amount > 0, Error::VaultInvalidRusdAmount);
 
     vault_utils.update_cumulative_funding_rate(asset, asset);
 
@@ -809,7 +807,6 @@ pub fn _buy_rusd(
     );
 
     let asset_amount = _transfer_in(asset, vault_storage_);
-    require(asset_amount > 0, Error::VaultInvalidAssetAmount);
 
     vault_utils.update_cumulative_funding_rate(asset, asset);
 
@@ -883,8 +880,7 @@ pub fn _direct_pool_deposit(
     );
 
     let amount = _transfer_in(asset, vault_storage_).as_u256();
-    // @TODO: check this
-    require(amount > 0, Error::VaultInvalidAssetAmount);
+
     vault_utils.increase_pool_amount(asset, amount);
 
     log(DirectPoolDeposit {

--- a/contracts/core/vault/src/utils.sw
+++ b/contracts/core/vault/src/utils.sw
@@ -749,7 +749,6 @@ pub fn _sell_rusd(
     // update asset balance
     let next_balance = balance_of(ContractId::this(), asset);
 
-    // _get_sell_rusd_fee_basis_points
     let fee_basis_points = vault_utils.get_fee_basis_points(
         asset,
         rusd_amount,
@@ -810,7 +809,6 @@ pub fn _buy_rusd(
     rusd_amount = vault_utils.adjust_for_decimals(rusd_amount, asset, rusd);
     require(rusd_amount > 0, Error::VaultInvalidRusdAmount);
 
-    // _get_buy_rusd_fee_basis_points
     let fee_basis_points = vault_utils.get_fee_basis_points(
         asset,
         rusd_amount,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "gen:contract:types": "sh ./utils/generate-contract-types.sh",
         "process:types": "python3 utils/process_types.py",
         "test": "hardhat test",
-        "test:specific": "hardhat test test/core/vault/decreaseShortPosition.test.ts",
+        "test:specific": "hardhat test test/core/vault/averagePrice.test.ts",
         "p": "biome format --write ."
     },
     "devDependencies": {

--- a/test/core/vault/averagePrice.test.ts
+++ b/test/core/vault/averagePrice.test.ts
@@ -157,7 +157,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
             await call(
                 vault
                     .as(user1)
@@ -170,7 +169,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
             await expect(
                 call(
                     vault
@@ -231,7 +229,6 @@ describe("Vault.averagePrice", () => {
                 ),
             ).to.be.revertedWith("VaultLiquidationFeesExceedCollateral")
 
-            await transfer(BTC.as(user1), contrToAccount(vault), 25000)
             await call(
                 vault
                     .connect(user0)
@@ -279,8 +276,6 @@ describe("Vault.averagePrice", () => {
 
             await validateVaultBalance(expect, vault, vaultStorage, vaultUtils, BTC)
         })
-
-        /*
         it("long position.averagePrice, buyPrice == averagePrice", async () => {
             await call(DAIPricefeed.functions.set_latest_answer(toPrice(1)))
             await call(vaultStorage.functions.set_asset_config(...getDaiConfig(DAI)))
@@ -292,16 +287,28 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-            await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-            await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [250000, getAssetId(BTC)],
+                    }),
+            )
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-            await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
+            await call(BTC.functions.mint(addrToAccount(user0), 25000))
+            // await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             )
 
             let position = formatObj(
@@ -323,12 +330,16 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(false)
             expect(delta[1]).eq("0")
 
-            await transfer(BTC.as(user1), contrToAccount(vault), 25000)
+            // await transfer(BTC.as(user1), contrToAccount(vault), 25000)
+            await call(BTC.functions.mint(addrToAccount(user0), 25000))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(10), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             )
 
             position = formatObj(
@@ -360,16 +371,28 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-            await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-            await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.0025 BTC => 100 USD
+                        forward: [250000, getAssetId(BTC)],
+                    }),
+            )
 
             await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-            await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
+            // await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             )
 
             let position = formatObj(
@@ -391,13 +414,15 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(true)
             expect(delta[1]).eq(toUsd(22.5))
 
-            await transfer(BTC.as(user1), contrToAccount(vault), 25000)
-
+            // await transfer(BTC.as(user1), contrToAccount(vault), 25000)
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(10), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             )
 
             position = formatObj(
@@ -426,16 +451,29 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
 
-            await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-            await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(BTC.as(user1), contrToAccount(vault), 250000)
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.0025 BTC => 100 USD
+                        forward: [250000, getAssetId(BTC)],
+                    }),
+            )
 
             await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-            await transfer(BTC.as(user1), contrToAccount(vault), 125000) // 0.000125 BTC => 50 USD
+            // await transfer(BTC.as(user1), contrToAccount(vault), 125000) // 0.000125 BTC => 50 USD
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.000125 BTC => 50 USD
+                        forward: [125000, getAssetId(BTC)],
+                    }),
             )
 
             let position = formatObj(
@@ -457,12 +495,15 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(false)
             expect(delta[1]).eq(toUsd(22.5))
 
-            await transfer(BTC.as(user1), contrToAccount(vault), 25000)
+            // await transfer(BTC.as(user1), contrToAccount(vault), 25000)
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(10), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             )
 
             position = formatObj(
@@ -489,16 +530,29 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-            await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-            await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.0025 BTC => 100 USD
+                        forward: [250000, getAssetId(BTC)],
+                    }),
+            )
 
             await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-            await transfer(BTC.as(user1), contrToAccount(vault), 125000) // 0.000125 BTC => 50 USD
+            // await transfer(BTC.as(user1), contrToAccount(vault), 125000) // 0.000125 BTC => 50 USD
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.000125 BTC => 50 USD
+                        forward: [125000, getAssetId(BTC)],
+                    }),
             )
 
             let position = formatObj(
@@ -520,12 +574,15 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(true)
             expect(delta[1]).eq("0")
 
-            await transfer(BTC.as(user1), contrToAccount(vault), 25000)
+            // await transfer(BTC.as(user1), contrToAccount(vault), 25000)
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(10), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             )
 
             position = formatObj(
@@ -562,16 +619,27 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101, 8)))
-            await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
-            await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(101, 8), getAssetId(DAI)],
+                    }),
+            )
 
             await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50, 8)))
-            await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
+            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(50, 8), getAssetId(DAI)],
+                    }),
             )
 
             let position = formatObj(
@@ -627,16 +695,27 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101, 8)))
-            await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
-            await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(101, 8), getAssetId(DAI)],
+                    }),
+            )
 
             await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50, 8)))
-            await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
+            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(50, 8), getAssetId(DAI)],
+                    }),
             )
 
             let position = formatObj(
@@ -692,16 +771,27 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101, 8)))
-            await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
-            await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(101, 8), getAssetId(DAI)],
+                    }),
+            )
 
             await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50, 8)))
-            await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
+            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(50, 8), getAssetId(DAI)],
+                    }),
             )
 
             let position = formatObj(
@@ -757,16 +847,27 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101, 8)))
-            await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
-            await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(101, 8), getAssetId(DAI)],
+                    }),
+            )
 
             await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50, 8)))
-            await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
+            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(50, 8), getAssetId(DAI)],
+                    }),
             )
 
             let position = formatObj(
@@ -829,11 +930,19 @@ describe("Vault.averagePrice", () => {
             await call(ETHPricefeed.functions.set_latest_answer("252145037536"))
 
             await call(ETH.functions.mint(addrToAccount(user1), expandDecimals(10, 8)))
-            await transfer(ETH.as(user1), contrToAccount(vault), expandDecimals(10, 8))
-            await call(vault.functions.buy_rusd(toAsset(ETH), addrToAccount(user1)).addContracts(attachedContracts))
+            // await transfer(ETH.as(user1), contrToAccount(vault), expandDecimals(10, 8))
+            await call(
+                vault
+                    .as(user1)
+                    .functions.buy_rusd(toAsset(ETH), addrToAccount(user1))
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(10, 8), getAssetId(ETH)],
+                    }),
+            )
 
             await call(ETH.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-            await transfer(ETH.as(user0), contrToAccount(vault), expandDecimals(1, 8))
+            // await transfer(ETH.as(user0), contrToAccount(vault), expandDecimals(1, 8))
             await call(
                 vault
                     .connect(user0)
@@ -844,7 +953,10 @@ describe("Vault.averagePrice", () => {
                         "5050322181222357947081599665915068",
                         true,
                     )
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(1, 8), getAssetId(ETH)],
+                    }),
             )
 
             let position = formatObj(
@@ -866,7 +978,6 @@ describe("Vault.averagePrice", () => {
             expect(delta[1]).eq("296866944860754376482796517102673")
 
             await call(ETH.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-            await transfer(ETH.as(user0), contrToAccount(vault), expandDecimals(1, 8))
             await call(
                 vault
                     .connect(user0)
@@ -877,7 +988,10 @@ describe("Vault.averagePrice", () => {
                         "4746470050780000000000000000000000",
                         true,
                     )
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        forward: [expandDecimals(1, 8), getAssetId(ETH)],
+                    }),
             )
 
             position = formatObj(
@@ -886,6 +1000,5 @@ describe("Vault.averagePrice", () => {
             expect(position[0]).eq("9796792232002357947081599665915068") // size
             expect(position[2]).eq("2447397190894361457116367555285124") // averagePrice
         })
-        */
     })
 })

--- a/test/core/vault/averagePrice.test.ts
+++ b/test/core/vault/averagePrice.test.ts
@@ -156,7 +156,7 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(41000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
             await call(
                 vault
                     .as(user1)
@@ -168,7 +168,7 @@ describe("Vault.averagePrice", () => {
                     }),
             )
 
-            await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
             await expect(
                 call(
                     vault
@@ -286,7 +286,7 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
             // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
             await call(
                 vault
@@ -298,7 +298,7 @@ describe("Vault.averagePrice", () => {
                     }),
             )
 
-            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
             await call(BTC.functions.mint(addrToAccount(user0), 25000))
             // await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
             await call(
@@ -370,7 +370,7 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
             // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
             await call(
                 vault
@@ -383,7 +383,7 @@ describe("Vault.averagePrice", () => {
                     }),
             )
 
-            await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
             // await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
             await call(
                 vault
@@ -449,7 +449,7 @@ describe("Vault.averagePrice", () => {
 
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
-            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
 
             // await transfer(BTC.as(user1), contrToAccount(vault), 250000)
             await call(
@@ -463,7 +463,7 @@ describe("Vault.averagePrice", () => {
                     }),
             )
 
-            await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
             // await transfer(BTC.as(user1), contrToAccount(vault), 125000) // 0.000125 BTC => 50 USD
             await call(
                 vault
@@ -529,7 +529,7 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
             // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
             await call(
                 vault
@@ -542,7 +542,7 @@ describe("Vault.averagePrice", () => {
                     }),
             )
 
-            await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
+            await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
             // await transfer(BTC.as(user1), contrToAccount(vault), 125000) // 0.000125 BTC => 50 USD
             await call(
                 vault
@@ -618,27 +618,27 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-            await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101, 8)))
-            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
+            await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101)))
+            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101))
             await call(
                 vault
                     .as(user1)
                     .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(101, 8), getAssetId(DAI)],
+                        forward: [expandDecimals(101), getAssetId(DAI)],
                     }),
             )
 
-            await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50, 8)))
-            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
+            await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50)))
+            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(50, 8), getAssetId(DAI)],
+                        forward: [expandDecimals(50), getAssetId(DAI)],
                     }),
             )
 
@@ -649,7 +649,7 @@ describe("Vault.averagePrice", () => {
             expect(position[1]).eq("49910000000000000000000000000000") // collateral, 50 - 90 * 0.1%
             expect(position[2]).eq(toNormalizedPrice(40000)) // averagePrice
             expect(position[3]).eq("0") // entryFundingRate
-            expect(position[4]).eq(expandDecimals(90, 8))
+            expect(position[4]).eq(expandDecimals(90))
 
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
@@ -675,7 +675,7 @@ describe("Vault.averagePrice", () => {
             expect(position[1]).eq("49900000000000000000000000000000") // collateral
             expect(position[2]).eq(toNormalizedPrice(40000)) // averagePrice
             expect(position[3]).eq("0") // entryFundingRate
-            expect(position[4]).eq(expandDecimals(100, 8)) // reserveAmount
+            expect(position[4]).eq(expandDecimals(100)) // reserveAmount
 
             delta = formatObj(
                 await getValue(vaultUtils.functions.get_position_delta(addrToAccount(user0), toAsset(DAI), toAsset(BTC), false)),
@@ -694,27 +694,27 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-            await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101, 8)))
-            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
+            await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101)))
+            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101))
             await call(
                 vault
                     .as(user1)
                     .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(101, 8), getAssetId(DAI)],
+                        forward: [expandDecimals(101), getAssetId(DAI)],
                     }),
             )
 
-            await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50, 8)))
-            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
+            await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50)))
+            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(50, 8), getAssetId(DAI)],
+                        forward: [expandDecimals(50), getAssetId(DAI)],
                     }),
             )
 
@@ -725,7 +725,7 @@ describe("Vault.averagePrice", () => {
             expect(position[1]).eq("49910000000000000000000000000000") // collateral, 50 - 90 * 0.1%
             expect(position[2]).eq(toNormalizedPrice(40000)) // averagePrice
             expect(position[3]).eq("0") // entryFundingRate
-            expect(position[4]).eq(expandDecimals(90, 8))
+            expect(position[4]).eq(expandDecimals(90))
 
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(50000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(50000)))
@@ -751,7 +751,7 @@ describe("Vault.averagePrice", () => {
             expect(position[1]).eq("49900000000000000000000000000000") // collateral
             expect(position[2]).eq("40816326530612244897959183673469387") // averagePrice
             expect(position[3]).eq("0") // entryFundingRate
-            expect(position[4]).eq(expandDecimals(100, 8)) // reserveAmount
+            expect(position[4]).eq(expandDecimals(100)) // reserveAmount
 
             delta = formatObj(
                 await getValue(vaultUtils.functions.get_position_delta(addrToAccount(user0), toAsset(DAI), toAsset(BTC), false)),
@@ -770,27 +770,27 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-            await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101, 8)))
-            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
+            await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101)))
+            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101))
             await call(
                 vault
                     .as(user1)
                     .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(101, 8), getAssetId(DAI)],
+                        forward: [expandDecimals(101), getAssetId(DAI)],
                     }),
             )
 
-            await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50, 8)))
-            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
+            await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50)))
+            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(50, 8), getAssetId(DAI)],
+                        forward: [expandDecimals(50), getAssetId(DAI)],
                     }),
             )
 
@@ -801,7 +801,7 @@ describe("Vault.averagePrice", () => {
             expect(position[1]).eq("49910000000000000000000000000000") // collateral, 50 - 90 * 0.1%
             expect(position[2]).eq(toNormalizedPrice(40000)) // averagePrice
             expect(position[3]).eq("0") // entryFundingRate
-            expect(position[4]).eq(expandDecimals(90, 8))
+            expect(position[4]).eq(expandDecimals(90))
 
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(30000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(30000)))
@@ -827,7 +827,7 @@ describe("Vault.averagePrice", () => {
             expect(position[1]).eq("49900000000000000000000000000000") // collateral
             expect(position[2]).eq("38709677419354838709677419354838709") // averagePrice
             expect(position[3]).eq("0") // entryFundingRate
-            expect(position[4]).eq(expandDecimals(100, 8)) // reserveAmount
+            expect(position[4]).eq(expandDecimals(100)) // reserveAmount
 
             delta = formatObj(
                 await getValue(vaultUtils.functions.get_position_delta(addrToAccount(user0), toAsset(DAI), toAsset(BTC), false)),
@@ -846,27 +846,27 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-            await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101, 8)))
-            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101, 8))
+            await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101)))
+            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101))
             await call(
                 vault
                     .as(user1)
                     .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(101, 8), getAssetId(DAI)],
+                        forward: [expandDecimals(101), getAssetId(DAI)],
                     }),
             )
 
-            await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50, 8)))
-            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50, 8))
+            await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50)))
+            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50))
             await call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(50, 8), getAssetId(DAI)],
+                        forward: [expandDecimals(50), getAssetId(DAI)],
                     }),
             )
 
@@ -877,7 +877,7 @@ describe("Vault.averagePrice", () => {
             expect(position[1]).eq("49910000000000000000000000000000") // collateral, 50 - 90 * 0.1%
             expect(position[2]).eq(toNormalizedPrice(40000)) // averagePrice
             expect(position[3]).eq("0") // entryFundingRate
-            expect(position[4]).eq(expandDecimals(90, 8))
+            expect(position[4]).eq(expandDecimals(90))
 
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(39700)))
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(39700)))
@@ -903,7 +903,7 @@ describe("Vault.averagePrice", () => {
             expect(position[1]).eq("49900000000000000000000000000000") // collateral
             expect(position[2]).eq(toUsd(39700)) // averagePrice
             expect(position[3]).eq("0") // entryFundingRate
-            expect(position[4]).eq(expandDecimals(100, 8)) // reserveAmount
+            expect(position[4]).eq(expandDecimals(100)) // reserveAmount
 
             delta = formatObj(
                 await getValue(vaultUtils.functions.get_position_delta(addrToAccount(user0), toAsset(DAI), toAsset(BTC), false)),
@@ -929,20 +929,20 @@ describe("Vault.averagePrice", () => {
             await call(ETHPricefeed.functions.set_latest_answer("252145037536"))
             await call(ETHPricefeed.functions.set_latest_answer("252145037536"))
 
-            await call(ETH.functions.mint(addrToAccount(user1), expandDecimals(10, 8)))
-            // await transfer(ETH.as(user1), contrToAccount(vault), expandDecimals(10, 8))
+            await call(ETH.functions.mint(addrToAccount(user1), expandDecimals(10)))
+            // await transfer(ETH.as(user1), contrToAccount(vault), expandDecimals(10))
             await call(
                 vault
                     .as(user1)
                     .functions.buy_rusd(toAsset(ETH), addrToAccount(user1))
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(10, 8), getAssetId(ETH)],
+                        forward: [expandDecimals(10), getAssetId(ETH)],
                     }),
             )
 
-            await call(ETH.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-            // await transfer(ETH.as(user0), contrToAccount(vault), expandDecimals(1, 8))
+            await call(ETH.functions.mint(addrToAccount(user0), expandDecimals(1)))
+            // await transfer(ETH.as(user0), contrToAccount(vault), expandDecimals(1))
             await call(
                 vault
                     .connect(user0)
@@ -955,7 +955,7 @@ describe("Vault.averagePrice", () => {
                     )
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(1, 8), getAssetId(ETH)],
+                        forward: [expandDecimals(1), getAssetId(ETH)],
                     }),
             )
 
@@ -977,7 +977,7 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(false)
             expect(delta[1]).eq("296866944860754376482796517102673")
 
-            await call(ETH.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
+            await call(ETH.functions.mint(addrToAccount(user0), expandDecimals(1)))
             await call(
                 vault
                     .connect(user0)
@@ -990,7 +990,7 @@ describe("Vault.averagePrice", () => {
                     )
                     .addContracts(attachedContracts)
                     .callParams({
-                        forward: [expandDecimals(1, 8), getAssetId(ETH)],
+                        forward: [expandDecimals(1), getAssetId(ETH)],
                     }),
             )
 

--- a/test/core/vault/averagePrice.test.ts
+++ b/test/core/vault/averagePrice.test.ts
@@ -287,7 +287,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
             await call(
                 vault
                     .as(user1)
@@ -300,7 +299,6 @@ describe("Vault.averagePrice", () => {
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
             await call(BTC.functions.mint(addrToAccount(user0), 25000))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
             await call(
                 vault
                     .connect(user0)
@@ -330,7 +328,6 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(false)
             expect(delta[1]).eq("0")
 
-            // await transfer(BTC.as(user1), contrToAccount(vault), 25000)
             await call(BTC.functions.mint(addrToAccount(user0), 25000))
             await call(
                 vault
@@ -371,7 +368,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
             await call(
                 vault
                     .as(user1)
@@ -384,7 +380,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
             await call(
                 vault
                     .connect(user0)
@@ -414,7 +409,6 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(true)
             expect(delta[1]).eq(toUsd(22.5))
 
-            // await transfer(BTC.as(user1), contrToAccount(vault), 25000)
             await call(
                 vault
                     .connect(user0)
@@ -451,7 +445,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
 
-            // await transfer(BTC.as(user1), contrToAccount(vault), 250000)
             await call(
                 vault
                     .as(user1)
@@ -464,7 +457,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 125000) // 0.000125 BTC => 50 USD
             await call(
                 vault
                     .connect(user0)
@@ -495,7 +487,6 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(false)
             expect(delta[1]).eq(toUsd(22.5))
 
-            // await transfer(BTC.as(user1), contrToAccount(vault), 25000)
             await call(
                 vault
                     .connect(user0)
@@ -530,7 +521,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
             await call(
                 vault
                     .as(user1)
@@ -543,7 +533,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-            // await transfer(BTC.as(user1), contrToAccount(vault), 125000) // 0.000125 BTC => 50 USD
             await call(
                 vault
                     .connect(user0)
@@ -574,7 +563,6 @@ describe("Vault.averagePrice", () => {
             expect(delta[0]).eq(true)
             expect(delta[1]).eq("0")
 
-            // await transfer(BTC.as(user1), contrToAccount(vault), 25000)
             await call(
                 vault
                     .connect(user0)
@@ -619,7 +607,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101)))
-            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101))
             await call(
                 vault
                     .as(user1)
@@ -631,7 +618,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50)))
-            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50))
             await call(
                 vault
                     .connect(user0)
@@ -695,7 +681,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101)))
-            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101))
             await call(
                 vault
                     .as(user1)
@@ -707,7 +692,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50)))
-            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50))
             await call(
                 vault
                     .connect(user0)
@@ -771,7 +755,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101)))
-            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101))
             await call(
                 vault
                     .as(user1)
@@ -783,7 +766,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50)))
-            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50))
             await call(
                 vault
                     .connect(user0)
@@ -847,7 +829,6 @@ describe("Vault.averagePrice", () => {
             await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
             await call(DAI.functions.mint(addrToAccount(user1), expandDecimals(101)))
-            // await transfer(DAI.as(user1), contrToAccount(vault), expandDecimals(101))
             await call(
                 vault
                     .as(user1)
@@ -859,7 +840,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(50)))
-            // await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(50))
             await call(
                 vault
                     .connect(user0)
@@ -930,7 +910,6 @@ describe("Vault.averagePrice", () => {
             await call(ETHPricefeed.functions.set_latest_answer("252145037536"))
 
             await call(ETH.functions.mint(addrToAccount(user1), expandDecimals(10)))
-            // await transfer(ETH.as(user1), contrToAccount(vault), expandDecimals(10))
             await call(
                 vault
                     .as(user1)
@@ -942,7 +921,6 @@ describe("Vault.averagePrice", () => {
             )
 
             await call(ETH.functions.mint(addrToAccount(user0), expandDecimals(1)))
-            // await transfer(ETH.as(user0), contrToAccount(vault), expandDecimals(1))
             await call(
                 vault
                     .connect(user0)

--- a/test/core/vault/buyRUSD.test.ts
+++ b/test/core/vault/buyRUSD.test.ts
@@ -150,8 +150,15 @@ describe("Vault.buyRUSD", () => {
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("0")
 
         await call(BNB.functions.mint(addrToAccount(user0), 100))
-        await transfer(BNB.connect(user0), contrToAccount(vault), 100)
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BNB), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BNB), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [100, getAssetId(BNB)],
+                }),
+        )
 
         expect(await getBalance(user0, RUSD)).eq("0")
         expect(await getBalance(user1, RUSD)).eq("29700")
@@ -167,7 +174,6 @@ describe("Vault.buyRUSD", () => {
         await call(vaultStorage.functions.set_asset_config(...getBnbConfig(BNB)))
 
         await call(BNB.functions.mint(addrToAccount(deployer.address), 100))
-        await transfer(BNB, contrToAccount(vault), 100)
 
         expect(await getBalance(deployer, RUSD)).eq("0")
 
@@ -176,7 +182,14 @@ describe("Vault.buyRUSD", () => {
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("0")
 
         await call(vaultStorage.functions.set_manager(addrToAccount(user0), true))
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BNB), addrToAccount(deployer)).addContracts(attachedContracts))
+        await call(
+            vault.functions
+                .buy_rusd(toAsset(BNB), addrToAccount(deployer))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [100, getAssetId(BNB)],
+                }),
+        )
 
         expect(await getBalance(deployer, RUSD)).eq("29700")
         expect(await getValStr(vaultStorage.functions.get_fee_reserves(toAsset(BNB)))).eq("1")
@@ -204,8 +217,15 @@ describe("Vault.buyRUSD", () => {
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BNB)))).eq("0")
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("0")
         await call(BNB.functions.mint(addrToAccount(user0), 100))
-        await transfer(BNB.connect(user0), contrToAccount(vault), 100)
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BNB), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BNB), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [100, getAssetId(BNB)],
+                }),
+        )
         expect(await getBalance(user0, RUSD)).eq("0")
         expect(await getBalance(user1, RUSD)).eq("19800")
 
@@ -231,8 +251,15 @@ describe("Vault.buyRUSD", () => {
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BNB)))).eq("0")
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("0")
         await call(BNB.functions.mint(addrToAccount(user0), 10000))
-        await transfer(BNB.connect(user0), contrToAccount(vault), 10000)
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BNB), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BNB), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [10000, getAssetId(BNB)],
+                }),
+        )
 
         expect(await getBalance(user0, RUSD)).eq("0")
         expect(await getBalance(user1, RUSD)).eq(asStr(9970 * 300))
@@ -268,8 +295,15 @@ describe("Vault.buyRUSD", () => {
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BNB)))).eq("0")
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("0")
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(10000)))
-        await transfer(DAI.connect(user0), contrToAccount(vault), expandDecimals(10000))
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(10000), getAssetId(DAI)],
+                }),
+        )
 
         expect(await getBalance(user0, RUSD)).eq("0")
         expect(await getBalance(user1, RUSD)).eq(expandDecimals(10000 - 4, 8))
@@ -295,8 +329,15 @@ describe("Vault.buyRUSD", () => {
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("0")
 
         await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-        await transfer(BTC.connect(user0), contrToAccount(vault), expandDecimals(1))
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(1, 8), getAssetId(BTC)],
+                }),
+        )
 
         expect(await getBalance(user0, RUSD)).eq("0")
         expect(await getValStr(vaultStorage.functions.get_fee_reserves(toAsset(BTC)))).eq("300000")

--- a/test/core/vault/closeLongPosition.test.ts
+++ b/test/core/vault/closeLongPosition.test.ts
@@ -138,17 +138,26 @@ describe("Vault.closeLongPosition", () => {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
         await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
         await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
 
         await expect(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(110), true)
                 .addContracts(attachedContracts)
+                .callParams({
+                    forward: [25000, getAssetId(BTC)],
+                })
                 .call(),
         ).to.be.revertedWith("VaultReserveExceedsPool")
 
@@ -156,7 +165,10 @@ describe("Vault.closeLongPosition", () => {
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [25000, getAssetId(BTC)],
+                }),
         )
 
         let position = formatObj(
@@ -230,16 +242,25 @@ describe("Vault.closeLongPosition", () => {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
         await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
         await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
         await expect(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(110), true)
                 .addContracts(attachedContracts)
+                .callParams({
+                    forward: [25000, getAssetId(BTC)],
+                })
                 .call(),
         ).to.be.revertedWith("VaultReserveExceedsPool")
 
@@ -247,7 +268,10 @@ describe("Vault.closeLongPosition", () => {
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [25000, getAssetId(BTC)],
+                }),
         )
 
         let position = formatObj(

--- a/test/core/vault/decreaseLongPosition.test.ts
+++ b/test/core/vault/decreaseLongPosition.test.ts
@@ -49,6 +49,7 @@ describe("Vault.decreaseLongPosition", () => {
     let timeDistributor: TimeDistributor
     let yieldTracker: YieldTracker
     let rlp: Rlp
+    
     beforeEach(async () => {
         const FUEL_NETWORK_URL = "http://127.0.0.1:4000/v1/graphql"
         const localProvider = await Provider.create(FUEL_NETWORK_URL)
@@ -184,17 +185,28 @@ describe("Vault.decreaseLongPosition", () => {
         ).to.be.revertedWith("VaultEmptyPosition")
 
         await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.0025 BTC => 100 USD
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
         await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
         await expect(
             call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(110), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.00025 BTC => 10 USD
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             ),
         ).to.be.revertedWith("VaultReserveExceedsPool")
 
@@ -202,7 +214,11 @@ describe("Vault.decreaseLongPosition", () => {
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.00025 BTC => 10 USD
+                    forward: [25000, getAssetId(BTC)],
+                }),
         )
 
         let position = formatObj(
@@ -342,15 +358,26 @@ describe("Vault.decreaseLongPosition", () => {
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(500)))
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(500)))
 
-        await call(BNB.functions.mint(contrToAccount(vault), expandDecimals(10)))
-        await call(vault.functions.buy_rusd(toAsset(BNB), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(BNB.functions.mint(addrToAccount(deployer), expandDecimals(10)))
+        await call(
+            vault.functions
+                .buy_rusd(toAsset(BNB), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(10), getAssetId(BNB)],
+                }),
+        )
 
-        await call(BNB.functions.mint(contrToAccount(vault), expandDecimals(1)))
+        await call(BNB.functions.mint(addrToAccount(deployer), expandDecimals(1)))
+        await call(BNB.functions.mint(addrToAccount(user0), expandDecimals(1)))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BNB), toAsset(BNB), toUsd(1000), true)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(1), getAssetId(BNB)],
+                }),
         )
 
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(750)))
@@ -433,17 +460,28 @@ describe("Vault.decreaseLongPosition", () => {
         ).to.be.revertedWith("VaultEmptyPosition")
 
         await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.0025 BTC => 100 USD
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
         await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
         await expect(
             call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(110), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.00025 BTC => 10 USD
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             ),
         ).to.be.revertedWith("VaultReserveExceedsPool")
 
@@ -451,7 +489,11 @@ describe("Vault.decreaseLongPosition", () => {
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.00025 BTC => 10 USD
+                    forward: [25000, getAssetId(BTC)],
+                }),
         )
 
         let position = formatObj(
@@ -508,17 +550,28 @@ describe("Vault.decreaseLongPosition", () => {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
         await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.0025 BTC => 100 USD
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
         await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
         await expect(
             call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(110), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.00025 BTC => 10 USD
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             ),
         ).to.be.revertedWith("VaultReserveExceedsPool")
 
@@ -526,7 +579,11 @@ describe("Vault.decreaseLongPosition", () => {
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.00025 BTC => 10 USD
+                    forward: [25000, getAssetId(BTC)],
+                }),
         )
 
         let position = formatObj(
@@ -649,17 +706,28 @@ describe("Vault.decreaseLongPosition", () => {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
         await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.0025 BTC => 100 USD
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
         await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
         await expect(
             call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(110), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.00025 BTC => 10 USD
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             ),
         ).to.be.revertedWith("VaultReserveExceedsPool")
 
@@ -667,7 +735,11 @@ describe("Vault.decreaseLongPosition", () => {
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.00025 BTC => 10 USD
+                    forward: [25000, getAssetId(BTC)],
+                }),
         )
 
         let position = formatObj(

--- a/test/core/vault/decreaseShortPosition.test.ts
+++ b/test/core/vault/decreaseShortPosition.test.ts
@@ -174,19 +174,28 @@ describe("Vault.decreaseShortPosition", () => {
         ).to.be.revertedWith("VaultEmptyPosition")
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(1000)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(100))
-        await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(100), getAssetId(DAI)],
+                }),
+        )
 
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(41000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(10))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(10), getAssetId(DAI)],
+                }),
         )
 
         let position = formatObj(
@@ -352,19 +361,28 @@ describe("Vault.decreaseShortPosition", () => {
         ).to.be.revertedWith("VaultEmptyPosition")
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(1000)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(100))
-        await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(100), getAssetId(DAI)],
+                }),
+        )
 
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(41000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(10))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(10), getAssetId(DAI)],
+                }),
         )
 
         let position = formatObj(
@@ -386,21 +404,6 @@ describe("Vault.decreaseShortPosition", () => {
         )
         expect(delta[0]).eq(true)
         expect(delta[1]).eq(toUsd(0))
-
-        // @TODO: uncomment when mineBlock is supported in Fuel
-        // await increaseTime(provider, 50 * 60)
-        // await mineBlock(provider)
-
-        // delta = formatObj(await getValue(vaultUtils.functions.get_position_delta(addrToAccount(user0), toAsset(DAI), toAsset(BTC), false)))
-        // expect(delta[0]).eq(true)
-        // expect(delta[1]).eq("0")
-
-        // await increaseTime(provider, 10 * 60 + 10)
-        // await mineBlock(provider)
-
-        // delta = formatObj(await getValue(vaultUtils.functions.get_position_delta(addrToAccount(user0), toAsset(DAI), toAsset(BTC), false)))
-        // expect(delta[0]).eq(true)
-        // expect(delta[1]).eq("67275000000000000000") // 0.67275
     })
 
     it("decreasePosition short with loss", async () => {
@@ -428,19 +431,28 @@ describe("Vault.decreaseShortPosition", () => {
         await call(vaultStorage.functions.set_asset_config(...getBtcConfig(BTC)))
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(1000)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(100))
-        await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(100), getAssetId(DAI)],
+                }),
+        )
 
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(41000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(10))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(10), getAssetId(DAI)],
+                }),
         )
 
         let position = formatObj(

--- a/test/core/vault/feeBasisPoints.test.ts
+++ b/test/core/vault/feeBasisPoints.test.ts
@@ -144,8 +144,16 @@ describe("Vault.getFeeBasisPoints", function () {
         await call(vaultStorage.functions.set_asset_config(...getBnbConfig(BNB)))
         expect(await getValStr(vaultUtils.functions.get_target_rusd_amount(toAsset(BNB)))).eq("0")
 
-        await call(BNB.functions.mint(contrToAccount(vault), 100))
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BNB), addrToAccount(deployer)).addContracts(attachedContracts))
+        await call(BNB.functions.mint(addrToAccount(user0), 100))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BNB), addrToAccount(deployer))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [100, getAssetId(BNB)],
+                }),
+        )
 
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BNB)))).eq("29700")
         expect(await getValStr(vaultUtils.functions.get_target_rusd_amount(toAsset(BNB)))).eq("29700")
@@ -180,8 +188,16 @@ describe("Vault.getFeeBasisPoints", function () {
         expect(await getValStr(vaultUtils.functions.get_fee_basis_points(toAsset(BNB), 25000, 100, 50, false))).eq("50")
         expect(await getValStr(vaultUtils.functions.get_fee_basis_points(toAsset(BNB), 100000, 100, 50, false))).eq("150")
 
-        await call(DAI.functions.mint(contrToAccount(vault), 20000))
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(DAI), addrToAccount(deployer)).addContracts(attachedContracts))
+        await call(DAI.functions.mint(addrToAccount(user0), 20000))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(deployer))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [20000, getAssetId(DAI)],
+                }),
+        )
 
         expect(await getValStr(vaultUtils.functions.get_target_rusd_amount(toAsset(BNB)))).eq("24850")
         expect(await getValStr(vaultUtils.functions.get_target_rusd_amount(toAsset(DAI)))).eq("24850")
@@ -207,8 +223,16 @@ describe("Vault.getFeeBasisPoints", function () {
         bnbConfig[2] = 5000
         await call(vaultStorage.functions.set_asset_config(...bnbConfig))
 
-        await call(BNB.functions.mint(contrToAccount(vault), 200))
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BNB), addrToAccount(deployer)).addContracts(attachedContracts))
+        await call(BNB.functions.mint(addrToAccount(user0), 200))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BNB), addrToAccount(deployer))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [200, getAssetId(BNB)],
+                }),
+        )
 
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BNB)))).eq("89100")
         expect(await getValStr(vaultUtils.functions.get_target_rusd_amount(toAsset(BNB)))).eq("36366")

--- a/test/core/vault/liquidateLongPosition.test.ts
+++ b/test/core/vault/liquidateLongPosition.test.ts
@@ -148,19 +148,31 @@ describe("Vault.liquidateLongPosition", () => {
             ),
         ).to.be.revertedWith("VaultEmptyPosition")
 
-        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
+        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
+        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
 
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.0025 BTC => 100 USD
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
-        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
+        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
 
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.00025 BTC => 10 USD
+                    forward: [25000, getAssetId(BTC)],
+                }),
         )
 
         let position = formatObj(
@@ -295,8 +307,16 @@ describe("Vault.liquidateLongPosition", () => {
 
         await call(vault.functions.withdraw_fees(toAsset(BTC), addrToAccount(user0)).addContracts(attachedContracts))
 
-        await call(BTC.functions.mint(contrToAccount(vault), 1000))
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        // await call(BTC.functions.mint(contrToAccount(vault), 1000))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [1000, getAssetId(BTC)],
+                }),
+        )
     })
 
     it("automatic stop-loss", async () => {
@@ -319,16 +339,28 @@ describe("Vault.liquidateLongPosition", () => {
             ),
         ).to.be.revertedWith("VaultEmptyPosition")
 
-        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 5000000) // 0.05 BTC => 2000 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.05 BTC => 2000 USD
+                    forward: [5000000, getAssetId(BTC)],
+                }),
+        )
 
-        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
+        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
+        await transfer(BTC.as(user1), addrToAccount(user0), 250000) // 0.0025 BTC => 100 USD
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(1000), true)
+                .callParams({
+                    // 0.0025 BTC => 100 USD
+                    forward: [250000, getAssetId(BTC)],
+                })
                 .addContracts(attachedContracts),
         )
 
@@ -459,7 +491,15 @@ describe("Vault.liquidateLongPosition", () => {
 
         await call(vault.functions.withdraw_fees(toAsset(BTC), addrToAccount(user0)).addContracts(attachedContracts))
 
-        await call(BTC.functions.mint(contrToAccount(vault), 1000))
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        // await call(BTC.functions.mint(contrToAccount(vault), 1000))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [1000, getAssetId(BTC)],
+                }),
+        )
     })
 })

--- a/test/core/vault/liquidateShortPosition.test.ts
+++ b/test/core/vault/liquidateShortPosition.test.ts
@@ -165,14 +165,23 @@ describe("Vault.liquidateShortPosition", function () {
         expect(await getValStr(vaultStorage.functions.get_global_short_average_prices(toAsset(BTC)))).eq("0")
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(1000)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(100))
-        await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(100), getAssetId(DAI)],
+                }),
+        )
 
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(10))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(90), false)
+                .callParams({
+                    forward: [expandDecimals(10), getAssetId(DAI)],
+                })
                 .addContracts(attachedContracts),
         )
         let position = formatObj(
@@ -293,11 +302,13 @@ describe("Vault.liquidateShortPosition", function () {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(50000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(50000)))
 
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(20))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(100), false)
+                .callParams({
+                    forward: [expandDecimals(20), getAssetId(DAI)],
+                })
                 .addContracts(attachedContracts),
         )
 
@@ -358,16 +369,25 @@ describe("Vault.liquidateShortPosition", function () {
         expect(await getValStr(vaultStorage.functions.get_global_short_average_prices(toAsset(BTC)))).eq("0")
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(1001)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(1001))
-        await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(1001), getAssetId(DAI)],
+                }),
+        )
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(100)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(100))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(1000), false)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(100), getAssetId(DAI)],
+                }),
         )
 
         let position = formatObj(
@@ -518,11 +538,13 @@ describe("Vault.liquidateShortPosition", function () {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(50000)))
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(20)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(20))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(100), false)
+                .callParams({
+                    forward: [expandDecimals(20), getAssetId(DAI)],
+                })
                 .addContracts(attachedContracts),
         )
 
@@ -583,16 +605,25 @@ describe("Vault.liquidateShortPosition", function () {
         expect(await getValStr(vaultStorage.functions.get_global_short_average_prices(toAsset(BTC)))).eq("0")
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(1001)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(1001))
-        await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
-
-        await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(100)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(100))
         await call(
             vault
-                .connect(user0)
+                .as(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(1001), getAssetId(DAI)],
+                }),
+        )
+
+        await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(100)))
+        await call(
+            vault
+                .as(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(1000), false)
-                .addContracts(attachedContracts),
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(100), getAssetId(DAI)],
+                }),
         )
 
         let position = formatObj(
@@ -724,11 +755,13 @@ describe("Vault.liquidateShortPosition", function () {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(50000)))
 
         await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(20)))
-        await transfer(DAI.as(user0), contrToAccount(vault), expandDecimals(20))
         await call(
             vault
-                .connect(user0)
+                .as(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BTC), toUsd(100), false)
+                .callParams({
+                    forward: [expandDecimals(20), getAssetId(DAI)],
+                })
                 .addContracts(attachedContracts),
         )
 

--- a/test/core/vault/settings.test.ts
+++ b/test/core/vault/settings.test.ts
@@ -137,10 +137,17 @@ describe("Vault.settings", function () {
         ).to.be.revertedWith("VaultInvalidAssetAmount")
 
         await call(BNB.functions.mint(addrToAccount(user0), 1000))
-        await transfer(BNB.as(user0), contrToAccount(vault), 1000)
 
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("0")
-        await call(vault.connect(user0).functions.direct_pool_deposit(toAsset(BNB)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.direct_pool_deposit(toAsset(BNB))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [1000, getAssetId(BNB)],
+                }),
+        )
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("1000")
 
         await validateVaultBalance(expect, vault, vaultStorage, vaultUtils, BNB)

--- a/test/core/vault/withdrawCollateral.test.ts
+++ b/test/core/vault/withdrawCollateral.test.ts
@@ -135,18 +135,29 @@ describe("Vault.withdrawCollateral", function () {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(41000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.0025 BTC => 100 USD
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
-        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
+        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
         await expect(
             call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(110), true)
-                    .addContracts(attachedContracts),
+                    .addContracts(attachedContracts)
+                    .callParams({
+                        // 0.00025 BTC => 10 USD
+                        forward: [25000, getAssetId(BTC)],
+                    }),
             ),
         ).to.be.revertedWith("VaultReserveExceedsPool")
 
@@ -154,6 +165,10 @@ describe("Vault.withdrawCollateral", function () {
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
+                .callParams({
+                    // 0.00025 BTC => 10 USD
+                    forward: [25000, getAssetId(BTC)],
+                })
                 .addContracts(attachedContracts),
         )
 
@@ -276,17 +291,28 @@ describe("Vault.withdrawCollateral", function () {
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(41000)))
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(40000)))
 
-        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1, 8)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 250000) // 0.0025 BTC => 100 USD
-        await call(vault.functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(BTC.functions.mint(addrToAccount(user1), expandDecimals(1)))
+        await call(
+            vault
+                .as(user1)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    // 0.0025 BTC => 100 USD
+                    forward: [250000, getAssetId(BTC)],
+                }),
+        )
 
-        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1, 8)))
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
+        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(1)))
         await expect(
             call(
                 vault
                     .connect(user0)
                     .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(110), true)
+                    .callParams({
+                        // 0.00025 BTC => 10 USD
+                        forward: [25000, getAssetId(BTC)],
+                    })
                     .addContracts(attachedContracts),
             ),
         ).to.be.revertedWith("VaultReserveExceedsPool")
@@ -295,6 +321,10 @@ describe("Vault.withdrawCollateral", function () {
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(90), true)
+                .callParams({
+                    // 0.00025 BTC => 10 USD
+                    forward: [25000, getAssetId(BTC)],
+                })
                 .addContracts(attachedContracts),
         )
         await call(BTCPricefeed.functions.set_latest_answer(toPrice(45100)))
@@ -336,11 +366,14 @@ describe("Vault.withdrawCollateral", function () {
                 .addContracts(attachedContracts),
         )
 
-        await transfer(BTC.as(user1), contrToAccount(vault), 25000) // 0.00025 BTC => 10 USD
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BTC), toAsset(BTC), toUsd(30), true)
+                .callParams({
+                    // 0.00025 BTC => 10 USD
+                    forward: [25000, getAssetId(BTC)],
+                })
                 .addContracts(attachedContracts),
         )
     })
@@ -355,14 +388,24 @@ describe("Vault.withdrawCollateral", function () {
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(500)))
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(500)))
 
-        await call(BNB.functions.mint(contrToAccount(vault), expandDecimals(10, 8)))
-        await call(vault.functions.buy_rusd(toAsset(BNB), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(BNB.functions.mint(addrToAccount(user0), expandDecimals(100)))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(BNB), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(10), getAssetId(BNB)],
+                }),
+        )
 
-        await call(BNB.functions.mint(contrToAccount(vault), expandDecimals(1, 8)))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BNB), toAsset(BNB), toUsd(2000), true)
+                .callParams({
+                    forward: [expandDecimals(1), getAssetId(BNB)],
+                })
                 .addContracts(attachedContracts),
         )
 
@@ -370,11 +413,13 @@ describe("Vault.withdrawCollateral", function () {
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(750)))
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(750)))
 
-        await call(BNB.functions.mint(contrToAccount(vault), expandDecimals(1, 8)))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(BNB), toAsset(BNB), toUsd(0), true)
+                .callParams({
+                    forward: [expandDecimals(1), getAssetId(BNB)],
+                })
                 .addContracts(attachedContracts),
         )
 
@@ -438,14 +483,24 @@ describe("Vault.withdrawCollateral", function () {
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(500)))
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(500)))
 
-        await call(DAI.functions.mint(contrToAccount(vault), expandDecimals(8000, 8)))
-        await call(vault.functions.buy_rusd(toAsset(DAI), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(DAI.functions.mint(addrToAccount(user0), expandDecimals(8000 + 500 + 500)))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(DAI), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(8000), getAssetId(DAI)],
+                }),
+        )
 
-        await call(DAI.functions.mint(contrToAccount(vault), expandDecimals(500, 8)))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BNB), toUsd(2000), false)
+                .callParams({
+                    forward: [expandDecimals(500), getAssetId(DAI)],
+                })
                 .addContracts(attachedContracts),
         )
 
@@ -453,11 +508,13 @@ describe("Vault.withdrawCollateral", function () {
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(525)))
         await call(BNBPricefeed.functions.set_latest_answer(toPrice(525)))
 
-        await call(DAI.functions.mint(contrToAccount(vault), expandDecimals(500, 8)))
         await call(
             vault
                 .connect(user0)
                 .functions.increase_position(addrToAccount(user0), toAsset(DAI), toAsset(BNB), toUsd(0), false)
+                .callParams({
+                    forward: [expandDecimals(500), getAssetId(DAI)],
+                })
                 .addContracts(attachedContracts),
         )
 

--- a/test/core/vault/withdrawFees.test.ts
+++ b/test/core/vault/withdrawFees.test.ts
@@ -130,7 +130,6 @@ describe("Vault.withdrawFees", function () {
         await call(vaultStorage.functions.set_asset_config(...getBtcConfig(BTC)))
 
         await call(BNB.functions.mint(addrToAccount(user0), expandDecimals(900)))
-        await transfer(BNB.as(user0), contrToAccount(vault), expandDecimals(900))
 
         expect(await getBalance(deployer, RUSD)).eq("0")
         expect(await getBalance(user1, RUSD)).eq("0")
@@ -138,7 +137,15 @@ describe("Vault.withdrawFees", function () {
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BNB)))).eq("0")
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("0")
 
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BNB), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BNB), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(900), getAssetId(BNB)],
+                }),
+        )
 
         expect(await getBalance(deployer, RUSD)).eq("0")
         expect(await getBalance(user1, RUSD)).eq("26919000000000") // 269,190 RUSD, 810 fee
@@ -148,26 +155,48 @@ describe("Vault.withdrawFees", function () {
         expect(await getValStr(rusd.functions.total_supply())).eq("26919000000000")
 
         await call(BNB.functions.mint(addrToAccount(user0), expandDecimals(200)))
-        await transfer(BNB.as(user0), contrToAccount(vault), expandDecimals(200))
 
-        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(2, 8)))
-        await transfer(BTC.as(user0), contrToAccount(vault), expandDecimals(2, 8))
+        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(2)))
 
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .as(user0)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(2), getAssetId(BTC)],
+                }),
+        )
+
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BTC)))).eq("11964000000000") // 119,640
         expect(await getValStr(rusd.functions.total_supply())).eq("38883000000000") // 388,830
 
-        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(2, 8)))
-        await transfer(BTC.as(user0), contrToAccount(vault), expandDecimals(2, 8))
+        await call(BTC.functions.mint(addrToAccount(user0), expandDecimals(2)))
 
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BTC), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BTC), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(2), getAssetId(BTC)],
+                }),
+        )
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BTC)))).eq("23928000000000") // 239,280
         expect(await getValStr(rusd.functions.total_supply())).eq("50847000000000") // 508,470
 
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BNB)))).eq("26919000000000") // 269,190
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("89730000000") // 897.3
 
-        await call(vault.connect(user0).functions.buy_rusd(toAsset(BNB), addrToAccount(user1)).addContracts(attachedContracts))
+        await call(
+            vault
+                .connect(user0)
+                .functions.buy_rusd(toAsset(BNB), addrToAccount(user1))
+                .addContracts(attachedContracts)
+                .callParams({
+                    forward: [expandDecimals(200), getAssetId(BNB)],
+                }),
+        )
 
         expect(await getValStr(vaultUtils.functions.get_rusd_amount(toAsset(BNB)))).eq("32901000000000") // 329,010
         expect(await getValStr(vaultUtils.functions.get_pool_amounts(toAsset(BNB)))).eq("109670000000") // 1096.7


### PR DESCRIPTION
closes #4 and #15 

cc @partylikeits1983